### PR TITLE
Content Model Generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.env

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - "0.10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: node_js
 node_js:
-  - '0.10'
+- '0.10'
 env:
   global:
   - secure: CoNID6YihIiX0Zt4d6bK5cqvQPJnkR9UWN4PAw54pRxdxMWBNVPs6xfXznijZ5EaRLF7lqWYO0pv4+eV25eJzlLH0u8qWDyShX3N3spw7mBuKU3X79/2VUAzRZQ2WEEw6HCW4kkh+LF5kpEmysCDwBcpnD3VmWHZnXgO3cu8Kzs=
   - secure: gAKjS+7E820CCJoeIxid/BA7IjizWDwFQzInnLFi23YVflMkC09mWNb28IE9QYZu3Uw1Qgnk0XHsPDRWACvDipmVgGoEF2bdKWO8dmugKKq4yCsfkgZCSEnr2jiMtkujTEO9zZen/Lpu8tw1/S6+ATxo/HHQ0F7wrZBPQV2C0hk=
   - secure: SgUe/nRZUND7IaQ2CytbtKUhWG2lixfyGXpCYWzv5BfIfLVZO1sQBVdgcGmha+7IPKx/ETag0uYTtpZzIlFAOgx/cqXFYwI2HN1cUbm7YVJUAbHzTt1r0zDrwLZCitZ75aPUmbAGqb69xkpIgW1zjci2b3wlnohbmxMD6Ah2FqU=
+  - secure: b5ZejNag8XRhL+VSZ8aCDZjxuL73MFnIAGUCoRPLwQHtnZPSYICqyshUCT7BZM60r9V9DVyAQYjlGzq29DCEOcUfifNLmF6j0+INk+Qrg1VKTgwpNg0DDKmsEpDlCci0iJmOcXS9lcZVfgzp33ite2FzCrnB1tPsMxrfQ104AWE=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
 language: node_js
 node_js:
-  - "0.10"
+  - '0.10'
+env:
+  global:
+  - secure: CoNID6YihIiX0Zt4d6bK5cqvQPJnkR9UWN4PAw54pRxdxMWBNVPs6xfXznijZ5EaRLF7lqWYO0pv4+eV25eJzlLH0u8qWDyShX3N3spw7mBuKU3X79/2VUAzRZQ2WEEw6HCW4kkh+LF5kpEmysCDwBcpnD3VmWHZnXgO3cu8Kzs=
+  - secure: gAKjS+7E820CCJoeIxid/BA7IjizWDwFQzInnLFi23YVflMkC09mWNb28IE9QYZu3Uw1Qgnk0XHsPDRWACvDipmVgGoEF2bdKWO8dmugKKq4yCsfkgZCSEnr2jiMtkujTEO9zZen/Lpu8tw1/S6+ATxo/HHQ0F7wrZBPQV2C0hk=
+  - secure: SgUe/nRZUND7IaQ2CytbtKUhWG2lixfyGXpCYWzv5BfIfLVZO1sQBVdgcGmha+7IPKx/ETag0uYTtpZzIlFAOgx/cqXFYwI2HN1cUbm7YVJUAbHzTt1r0zDrwLZCitZ75aPUmbAGqb69xkpIgW1zjci2b3wlnohbmxMD6Ah2FqU=

--- a/generators/model.coffee
+++ b/generators/model.coffee
@@ -1,0 +1,15 @@
+path       = require 'path'
+contentful = require 'contentful-management'
+
+log = console.log.bind(console)
+
+module.exports = (utils, name) ->
+  cwd    = process.cwd()
+  config = require(path.join(cwd, 'contentful'))
+  client = contentful.createClient(accessToken: config.management_token)
+
+  client.getSpace(config.space_id)
+    .then (space) ->
+      space.createContentType
+        name: name
+    .then(log.ok, log.fail)

--- a/generators/model.coffee
+++ b/generators/model.coffee
@@ -1,9 +1,38 @@
 path       = require 'path'
+_          = require 'lodash'
+s          = require 'underscore.string'
 contentful = require 'contentful-management'
 
 log = console.log.bind(console)
 
+valid_field_types = [
+  "Symbol"
+  "Text"
+  "Integer"
+  "Number"
+  "Date"
+  "Boolean"
+  "Link"
+  "Array"
+  "Object"
+]
+
+validate_field_type = (type) ->
+  if not _.contains(valid_field_types, type)
+    throw new Error("#{type} is not a valid Contentful field type")
+
+parse_fields = (fields) ->
+  _.reduce fields, (res, field) ->
+    split = field.split(':')
+    name  = split[0]
+    type  = s.capitalize(split[1]) || 'Text'
+    validate_field_type(type)
+    res.push(name: name, type: type)
+    return res
+  , []
+
 module.exports = (utils, name) ->
+  fields = parse_fields(Array.prototype.slice.call(arguments, 2))
   cwd    = process.cwd()
   config = require(path.join(cwd, 'contentful'))
   client = contentful.createClient(accessToken: config.management_token)
@@ -12,4 +41,5 @@ module.exports = (utils, name) ->
     .then (space) ->
       space.createContentType
         name: name
+        fields: fields
     .then(log.ok, log.fail)

--- a/init.coffee
+++ b/init.coffee
@@ -1,31 +1,25 @@
 exports.configure = [
   {
-    type: 'input',
     name: 'name',
     message: 'What is the name of your project?'
   },
   {
-    type: 'input',
     name: 'description',
     message: 'Describe your project'
   },
   {
-    type: 'input',
     name: 'delivery_token',
     message: 'What is your Contentful Delivery API token?'
   },
   {
-    type: 'input',
     name: 'management_token',
     message: 'What is your Contentful Managment API token?'
   },
   {
-    type: 'input',
     name: 'space_id',
     message: 'What is your Contentful Space ID?'
   },
   {
-    type: 'input',
     name: 'netlify_token',
     message: 'What is your Netlify access token?'
   }

--- a/init.coffee
+++ b/init.coffee
@@ -11,8 +11,13 @@ exports.configure = [
   },
   {
     type: 'input',
-    name: 'contentful_token',
+    name: 'delivery_token',
     message: 'What is your Contentful Delivery API token?'
+  },
+  {
+    type: 'input',
+    name: 'management_token',
+    message: 'What is your Contentful Managment API token?'
   },
   {
     type: 'input',

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "directories": {
     "test": "test"
   },
-  "dependencies": {},
+  "dependencies": {
+    "contentful-management": "0.1.x"
+  },
   "devDependencies": {
     "chai": "2.2.x",
     "coffee-script": "1.9.x",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "test": "test"
   },
   "dependencies": {
-    "contentful-management": "0.1.x"
+    "contentful-management": "0.1.x",
+    "lodash": "3.6.x",
+    "underscore.string": "3.0.x"
   },
   "devDependencies": {
     "chai": "2.2.x",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "chai": "2.2.x",
     "coffee-script": "1.9.x",
+    "dotenv": "1.1.x",
     "mocha": "2.2.x",
     "rimraf": "2.3.x",
     "sprout": "0.2.x",

--- a/package.json
+++ b/package.json
@@ -8,11 +8,12 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "chai": "^2.2.0",
-    "mocha": "^2.2.1",
-    "rimraf": "^2.3.2",
-    "sprout": "^0.2.1",
-    "when": "^3.7.2"
+    "chai": "2.2.x",
+    "coffee-script": "1.9.x",
+    "mocha": "2.2.x",
+    "rimraf": "2.3.x",
+    "sprout": "0.2.x",
+    "when": "3.7.x"
   },
   "scripts": {
     "test": "mocha"

--- a/readme.md
+++ b/readme.md
@@ -49,10 +49,24 @@ sprout run static-cms model Post title:text description:text slug:symbol date:da
 
 If you don't specify a field type, sprout will default to a text field.
 
+
+#### Tests
+
+In order to run the tests, you'll need to add a couple environment variables. This project is setup to use [dotenv](https://github.com/motdotla/dotenv), so all you should need to do is add a `.env` file with the following variables:
+
+```
+DELIVERY_TOKEN=XXXXXXXXXXXX
+MANAGEMENT_TOKEN=XXXXXXXXXXXX
+SPACE_ID=XXXXXXXXXXXX
+```
+
+You should use a test Contentful account (i.e. not in use in production) to populate these values.
+
 ### Options
 
 - **name** (name of template)
 - **description** (a short description of the template)
-- **delivery_token** (your Contentful account's Delivery API access token)
 - **space_id** (the ID for the Contentful space associated with this project)
+- **delivery_token** (your Contentful space's Delivery API token)
+- **management_token** (your Contentful account's Management API token)
 - **netlify_token** (your Netlify account's personal access token)

--- a/readme.md
+++ b/readme.md
@@ -37,6 +37,8 @@ You will need the following set up before you run this:
 
 ### Generators
 
+Once your static CMS project is set up, this template will also give you useful generators. These generators rely on `contentful.coffee` in order to provide the credentials needed to interact with Contentful, **do not move this file if you need to use a generator**.
+
 #### Model Generator
 
 Sprout-static-cms comes equipped with a Contentful Content Model generator. Pass in the Content Model's name followed by a list of fields to generate following a `name:type` format, for example:

--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,18 @@ You will need the following set up before you run this:
 3. Under Personal Access Tokens, create a new token.
 4. Note your Netlify API token, you'll need this for the template.
 
+### Generators
+
+#### Model Generator
+
+Sprout-static-cms comes equipped with a Contentful Content Model generator. Pass in the Content Model's name followed by a list of fields to generate following a `name:type` format, for example:
+
+```bash
+sprout run static-cms model Post title:text description:text slug:symbol date:date rank:integer price:number private:boolean
+``` 
+
+If you don't specify a field type, sprout will default to a text field.
+
 ### Options
 
 - **name** (name of template)

--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,6 @@ You will need the following set up before you run this:
 
 - **name** (name of template)
 - **description** (a short description of the template)
-- **contentful_token** (your Contentful account's Delivery API access token)
+- **delivery_token** (your Contentful account's Delivery API access token)
 - **space_id** (the ID for the Contentful space associated with this project)
 - **netlify_token** (your Netlify account's personal access token)

--- a/root/app.coffee
+++ b/root/app.coffee
@@ -5,7 +5,10 @@ contentful   = require 'roots-contentful'
 config       = require './contentful'
 
 module.exports =
-  ignores: ['readme.md', '**/layout.*', '**/_*', '.gitignore', 'contentful.coffee']
+  ignores: [
+    'readme.md', '**/layout.*', '**/_*', '.gitignore', 'contentful.coffee',
+    'Makefile', 'ship*'
+  ]
 
   stylus:
     use: [axis(), rupture(), autoprefixer()]

--- a/root/app.coffee
+++ b/root/app.coffee
@@ -2,25 +2,12 @@ axis         = require 'axis'
 rupture      = require 'rupture'
 autoprefixer = require 'autoprefixer-stylus'
 contentful   = require 'roots-contentful'
+config       = require 'contentful_config'
 
 module.exports =
-  ignores: ['readme.md', '**/layout.*', '**/_*', '.gitignore']
+  ignores: ['readme.md', '**/layout.*', '**/_*', '.gitignore', 'contentful.coffee']
 
   stylus:
     use: [axis(), rupture(), autoprefixer()]
 
-  extensions: [
-    contentful
-      access_token: '<%= delivery_token %>'
-      management_token: '<%= management_token %>'
-      space_id: '<%= space_id %>'
-      content_types: [
-        # {
-        #   id: 'xxxx'                    # ID of your content type
-        #   name: 'posts'                 # data will be made available through this key on the `contentful` object in your templates
-        #   filters: {}                   # passes filters to the call to contentful's API, see contentful's docs for more info
-        #   template: 'path/to/template'  # if present a single page view will be created for each entry in the content type
-        #   path: (entry) ->              # override function for generating single page file path, passed in the entry object
-        # }
-      ]
-  ]
+  extensions: [contentful(config)]

--- a/root/app.coffee
+++ b/root/app.coffee
@@ -11,7 +11,8 @@ module.exports =
 
   extensions: [
     contentful
-      access_token: '<%= contentful_token %>'
+      access_token: '<%= delivery_token %>'
+      management_token: '<%= management_token %>'
       space_id: '<%= space_id %>'
       content_types: [
         # {

--- a/root/app.coffee
+++ b/root/app.coffee
@@ -2,7 +2,7 @@ axis         = require 'axis'
 rupture      = require 'rupture'
 autoprefixer = require 'autoprefixer-stylus'
 contentful   = require 'roots-contentful'
-config       = require 'contentful_config'
+config       = require './contentful'
 
 module.exports =
   ignores: ['readme.md', '**/layout.*', '**/_*', '.gitignore', 'contentful.coffee']

--- a/root/contentful.coffee
+++ b/root/contentful.coffee
@@ -1,0 +1,13 @@
+module.exports = 
+  access_token: '<%= delivery_token %>'
+  management_token: '<%= management_token %>'
+  space_id: '<%= space_id %>'
+  content_types: [
+    # {
+    #   id: 'xxxx'                    # ID of your content type
+    #   name: 'posts'                 # data will be made available through this key on the `contentful` object in your templates
+    #   filters: {}                   # passes filters to the call to contentful's API, see contentful's docs for more info
+    #   template: 'path/to/template'  # if present a single page view will be created for each entry in the content type
+    #   path: (entry) ->              # override function for generating single page file path, passed in the entry object
+    # }
+  ]

--- a/root/package.json
+++ b/root/package.json
@@ -2,14 +2,14 @@
   "name": "<%= S.slugify(name) %>",
   "description": "<%= description %>",
   "dependencies": {
-    "jade": "1.x",
+    "jade": "1.9.x",
     "marked": "0.3.x",
-    "stylus": "0.48.x",
-    "coffee-script": "1.8.x",
-    "autoprefixer-stylus": "0.3.x",
+    "stylus": "0.50.x",
+    "coffee-script": "1.9.x",
+    "autoprefixer-stylus": "0.5.x",
     "axis": "0.3.x",
-    "rupture": "0.4.x",
-    "roots": "3.0.0-rc.10",
+    "rupture": "0.6.x",
+    "roots": "3.0.x",
     "roots-contentful": "0.0.3",
     "ship": "0.2.x"
   }

--- a/test/fixtures/locals.json
+++ b/test/fixtures/locals.json
@@ -1,7 +1,8 @@
 {
   "name": "static-cms",
   "description": "A static CMS.",
-  "contentful_token": "test_contentful_token",
+  "delivery_token": "test_contentful_token",
+  "management_token": "test_management_token",
   "space_id": "test_space_id",
   "netlify_token": "test_netlify_token"
 }

--- a/test/fixtures/locals.json
+++ b/test/fixtures/locals.json
@@ -1,8 +1,5 @@
 {
   "name": "static-cms",
   "description": "A static CMS.",
-  "delivery_token": "test_contentful_token",
-  "management_token": "test_management_token",
-  "space_id": "test_space_id",
   "netlify_token": "test_netlify_token"
 }

--- a/test/support/helper.js
+++ b/test/support/helper.js
@@ -1,8 +1,11 @@
-require('dotenv').load()
-
 var chai   = require('chai'),
     path   = require('path'),
+    fs     = require('fs'),
     Sprout = require('sprout');
+
+if (fs.existsSync(path.join(process.cwd(), '.env'))) {
+  require('dotenv').load()
+}
 
 var sprout = new Sprout(path.join(__dirname, '../config'));
 

--- a/test/support/helper.js
+++ b/test/support/helper.js
@@ -1,10 +1,21 @@
+require('dotenv').load()
+
 var chai   = require('chai'),
     path   = require('path'),
     Sprout = require('sprout');
 
 var sprout = new Sprout(path.join(__dirname, '../config'));
 
+var _path  = path.join(__dirname, '../fixtures');
+var locals = require(path.join(_path, 'locals.json'))
+var ENV    = process.env
+
+locals.delivery_token   = ENV['DELIVERY_TOKEN']
+locals.management_token = ENV['MANAGEMENT_TOKEN']
+locals.space_id         = ENV['SPACE_ID']
+
 global.chai   = chai;
 global.sprout = sprout;
 global.expect = chai.expect;
-global._path  = path.join(__dirname, '../fixtures');
+global._path  = _path
+global.locals = locals

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -13,7 +13,6 @@ locals      = require(locals_path)
 
 opts =
   config: locals_path
-  branch: 'tests'
   verbose: true
 
 before (done) ->
@@ -27,8 +26,8 @@ after ->
 
 describe 'sprout-static-cms', ->
 
-  it 'should load the correct values into app.coffee', (done) ->
-    nodefn.call(fs.readFile, path.join(test_path, 'app.coffee'), 'utf8')
+  it 'should load the correct values into contentful.coffee', (done) ->
+    nodefn.call(fs.readFile, path.join(test_path, 'contentful.coffee'), 'utf8')
       .then (res) ->
         expect(res).to.have.string "access_token: '#{locals.delivery_token}'"
         expect(res).to.have.string "management_token: '#{locals.management_token}'"

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -8,11 +8,8 @@ test_path          = path.join(__dirname, 'tmp')
 
 tpl = 'sprout-static-cms'
 
-locals_path = path.join(_path, 'locals.json')
-locals      = require(locals_path)
-
 opts =
-  config: locals_path
+  locals: locals
   verbose: true
 
 before (done) ->

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -22,7 +22,6 @@ after ->
   sprout.remove(tpl).then -> rimraf.sync(test_path)
 
 describe 'sprout-static-cms', ->
-
   it 'should load the correct values into contentful.coffee', (done) ->
     nodefn.call(fs.readFile, path.join(test_path, 'contentful.coffee'), 'utf8')
       .then (res) ->

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -30,7 +30,8 @@ describe 'sprout-static-cms', ->
   it 'should load the correct values into app.coffee', (done) ->
     nodefn.call(fs.readFile, path.join(test_path, 'app.coffee'), 'utf8')
       .then (res) ->
-        expect(res).to.have.string "access_token: '#{locals.contentful_token}'"
+        expect(res).to.have.string "access_token: '#{locals.delivery_token}'"
+        expect(res).to.have.string "management_token: '#{locals.management_token}'"
         expect(res).to.have.string "space_id: '#{locals.space_id}'"
       .then(-> done()).catch(done)
 


### PR DESCRIPTION
This adds a Contentful Content Model generator to the template. Still very much WIP, but opening this PR to solicit feedback on the initial interface. Keeping it very similar to Rails conventions so:

``` bash
$ sprout run static-cms model Post title:text description:text slug:symbol date:date rank:integer price:number private:boolean
```

Still work to be done on testing all the field types. Down the road, I think editing commands could be added, as well as auto generation of sample entries and a sample view showing how to load it. It might also be useful to keep a schema on the content models that's synced with Contentful. Lots of potential here.
